### PR TITLE
Fix the failing GitHub Actions job "sigridci"

### DIFF
--- a/.github/workflows/sigrid-publish.yml
+++ b/.github/workflows/sigrid-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Sigrid CI
         uses: Software-Improvement-Group/sigridci@main
         with:
-          customer: Miles Sigrid Trial
+          customer: Miles
           system: puckplan
           publishonly: true
         env:

--- a/.github/workflows/sigrid-publish.yml
+++ b/.github/workflows/sigrid-publish.yml
@@ -1,0 +1,22 @@
+name: Publish to Sigrid
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sigridci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Sigrid CI
+        uses: Software-Improvement-Group/sigridci@main
+        with:
+          customer: Miles Sigrid Trial
+          system: puckplan
+          publishonly: true
+        env:
+          SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"

--- a/.github/workflows/sigrid-pullrequest.yml
+++ b/.github/workflows/sigrid-pullrequest.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Sigrid CI
         uses: Software-Improvement-Group/sigridci@main
         with:
-          customer: Miles Sigrid Trial
+          customer: Miles
           system: puckplan
         env:
           SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"

--- a/.github/workflows/sigrid-pullrequest.yml
+++ b/.github/workflows/sigrid-pullrequest.yml
@@ -1,0 +1,27 @@
+name: Sigrid pull request feedback
+on: [pull_request]
+
+jobs:
+  sigridci:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Sigrid CI
+        uses: Software-Improvement-Group/sigridci@main
+        with:
+          customer: Miles Sigrid Trial
+          system: puckplan
+        env:
+          SIGRID_CI_TOKEN: "${{ secrets.SIGRID_CI_TOKEN }}"
+      - name: "Sigrid pull request feedback"
+        uses: mshick/add-pr-comment@v2
+        if: always()
+        with:
+          message-id: sigrid
+          message-path: sigrid-ci-output/*feedback.md

--- a/.github/workflows/sigrid-pullrequest.yml
+++ b/.github/workflows/sigrid-pullrequest.yml
@@ -22,6 +22,7 @@ jobs:
       - name: "Sigrid pull request feedback"
         uses: mshick/add-pr-comment@v2
         if: always()
+        continue-on-error: true
         with:
           message-id: sigrid
           message-path: sigrid-ci-output/*feedback.md


### PR DESCRIPTION
The `sigridci` job was failing due to the `mshick/add-pr-comment@v2` step erroring with `no message, check your message inputs`. On the first run, Sigrid CI only on-boards the system and does not produce feedback markdown files, so the `message-path: sigrid-ci-output/*feedback.md` glob matched nothing, causing the action to fail.

## Fix

Added `continue-on-error: true` to the "Sigrid pull request feedback" step in `.github/workflows/sigrid-pullrequest.yml`. This allows the job to pass when no feedback file is generated (e.g., during initial on-boarding), while still posting the Sigrid feedback comment on subsequent runs once analysis results are available.