### PR TITLE
Add opencode config with 1Password auth plugin

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["opencode-1password-auth"]
+}


### PR DESCRIPTION
Adds a project-level `opencode.json` that registers the `opencode-1password-auth` plugin, so opencode can resolve secrets (e.g. MCP `{env:VAR}` values) from 1Password instead of plaintext.

## Notes
- Plugin: [`opencode-1password-auth`](https://www.npmjs.com/package/opencode-1password-auth) (MIT). Installed automatically by opencode on next start.
- Requires a restart of opencode to load.
- Needs `OP_SERVICE_ACCOUNT_TOKEN` and `OP_CONFIG_ENV_ID` env vars set system-wide to actually inject secrets.